### PR TITLE
Support self-referential identifiers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ wheel==0.43.0
     # via pip-tools
 tqdm==4.67.1
 
-lark==1.1.9
+lark==1.2.2
 
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/dvrtl.lark
+++ b/src/dvrtl.lark
@@ -44,7 +44,7 @@ MULTILINE_COMMENT: /\/\*(\*(?!\/)|[^*])*\*\//
 %ignore MULTILINE_COMMENT
 %ignore NEWLINE
 
-?identifier: IDENTIFIER
+?identifier: IDENTIFIER -> identifier
 
 IDENTIFIER: CNAME
           | ESCAPED_IDENTIFIER

--- a/src/syntax.py
+++ b/src/syntax.py
@@ -48,6 +48,9 @@ class Node:
     # Returns a human-readable version of the node
     def serialize(self) -> str:
         return self.name
+    
+    def toString(self) -> str:
+        return str(self)
 
 # Statement in our circuit, these are the core nodes of a design.
 class Stmt(Node):
@@ -67,6 +70,7 @@ class Symbol(Node):
     def __eq__(self, value) -> bool:
         return isinstance(value, Symbol) and self.name == value.name
     
+    @override
     def toString(self) -> str:
         return f"{self.name}: {self.expr}"
 
@@ -99,6 +103,9 @@ class Circuit:
             self.body, \
             "" \
         )
+    
+    def toString(self) -> str:
+        return f"BODY: {str(list(map(lambda s: s.toString(), self.body)))}\n CONTEXT: {str(self.context)}"
     
 
 ################################################
@@ -182,6 +189,10 @@ class AOp(Arith):
             self.ops, "" \
         )
         return f"{self.name} {operands_s}"
+    
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n OPERANDS: {self.ops}"
 
 # Arithmetic binary operator
 class ABinOp(AOp):
@@ -319,6 +330,10 @@ class EOp(Expr):
             self.ops, "" \
         )
         return f"{self.name} {operands_s}"
+    
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n OPERANDS: {self.ops}"
 
 # Synthesizable binary operator
 class EBinOp(EOp):
@@ -421,6 +436,10 @@ class ContractOp(Node):
     @override
     def serialize(self) -> str:
         return f"{self.name} {self.cond.serialize()}"
+    
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n COND: {self.cond}"
 
 # Postcondition arithmetic expression
 # Only valid in a module definition
@@ -449,6 +468,10 @@ class Contract(Node):
     @override
     def serialize(self) -> str:
         return f"[{self.pre.serialize()}; {self.post.serialize()}]"
+    
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n PRECOND: {self.pre}\n POSTCOND: {self.post}"
 
 # Special result reference
 # Only valid inside of a postcondition
@@ -498,6 +521,10 @@ class Body(Node):
                 lambda acc, stmt: acc + f"\t {stmt.serialize()}\n",\
                 self.stmts, "{\n" \
             ) + "}"
+    
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n STMTS: {self.stmts}\n OUT: {self.out}"
 
 
 # Module definition
@@ -509,13 +536,17 @@ class Module(Stmt):
     def __init__( \
             self, \
             args: list[In], \
-            contract: Optional[ContractOp], \
+            contract: Optional[Contract], \
             body: Body \
     ) -> None:
         super().__init__("mod")
         self.args: list[In] = args
-        self.contract: Optional[ContractOp] = contract
+        self.contract: Optional[Contract] = contract
         self.body: Body = body 
+
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n ARGS: {self.args}\n CONTRACT: {self.contract}\n BODY: {self.body}"
 
 # Arguments can typically be any named thing or unnamed expression
 Arg: TypeAlias = Symbol | Expr | In
@@ -581,6 +612,10 @@ class Bind(Def):
     def serialize(self) -> str:
         return f"{self.name} = {self.e.serialize()}"
     
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n EXPR: {self.e.toString()}"
+    
 
 # Register Definition
 #   Notation: 
@@ -610,6 +645,10 @@ class Reg(Def):
     @override
     def serialize(self) -> str:
         return f"{self.name} -> {self.init.serialize()}, {self.next.serialize()}"
+    
+    @override
+    def toString(self) -> str:
+        return f"NAME: {self.name}\n INIT: {self.init}\n NEXT: {self.next}"
     
 
 # Abstract Node for a verification statement

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -52,6 +52,7 @@ class DVRTLTransformer(Transformer):
     ## Base elements
     def identifier(self, c):
         (id,) = c 
+        print(id)
         # Check context for content
         ref: Symbol = [s for s in self.context if s == Symbol(id[1:-1], None)][0]
         return ref
@@ -101,6 +102,7 @@ class DVRTLTransformer(Transformer):
         (id, l_e) = (c[0], c[1:]) 
         # print(id)
         # print(list(map(lambda s: s.toString(), self.context)))
+        # fetch module referenced by symbol
         mod: Module = [ \
             s.expr for s in self.context \
             if s.name == id and isinstance(s.expr, Module) \

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -54,13 +54,13 @@ class DVRTLTransformer(Transformer):
         (id,) = c 
         print(id)
         # Check context for content
-        ref: Symbol = [s for s in self.context if s == Symbol(id, None)][0]
-        return ref
+        ref: list[Symbol] = [s for s in self.context if s == Symbol(id, None)]
+        return ref[0] if len(ref) > 0 else Symbol(id, None)
     
     def list_of_variables(self, c):
         # Unpack children
-        (id, l_id) = (c[0][1:-1], c[1:])
-        return list(id).append(l_id)
+        (id, l_id) = (c[0], c[1:])
+        return [id].append(l_id)
     
     def list_of_expr(self, c):
         # unpack children

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -54,7 +54,7 @@ class DVRTLTransformer(Transformer):
         (id,) = c 
         print(id)
         # Check context for content
-        ref: Symbol = [s for s in self.context if s == Symbol(id[1:-1], None)][0]
+        ref: Symbol = [s for s in self.context if s == Symbol(id, None)][0]
         return ref
     
     def list_of_variables(self, c):

--- a/tests/dv/untyped.dv
+++ b/tests/dv/untyped.dv
@@ -15,21 +15,21 @@ add2_0 = mod (a1, a0, b1, b0) [
     ens res eq (a0 + b0)
 ] {
     out sum(a0, b0, 0)
-};
+}
 add2_1 = mod (a1, a0, b1, b0) [
     req 1
     ens res eq ((a0 and b0) + (a1 + b1))
 ]{
     c_0 = carry(a0, b0, 0)
     out sum(a1, b1, c_0)
-};
+}
 carry2 = mod (a1, a0, b1, b0) [
     req 1
     ens res eq ((a0 and b0) + (a1 and b1))
 ]{
     carry0 = carry(a0, b0, 0)
     out carry(a1, b1, carry0)
-};
+}
 bit0 = add2_0(0,1,0,1)
 bit1 = add2_1(0,1,0,1)
 overflow = carry2(0,1,0,1)

--- a/tests/test.py
+++ b/tests/test.py
@@ -470,6 +470,7 @@ class DVRTLTestParser(unittest.TestCase):
           identifier\toverflow
           zero
 """
+        self.maxDiff = None
         self.assertEqual(parser.tree.pretty(), expected_tree)
 
         print("test parse tree untyped passed")

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,33 +39,33 @@ class DVRTLTestParser(unittest.TestCase):
 
         expected_tree: str = """start
   reg
-    A
+    identifier\tA
     zero
     expr_xor
-      C
+      identifier\tC
       scoped_expr
         expr_xor
-          a
-          b
+          identifier\ta
+          identifier\tb
   reg
-    B
+    identifier\tB
     one
-    B
+    identifier\tB
   reg
-    C
+    identifier\tC
     zero
     expr_or
       scoped_expr
         expr_and
-          A
-          B
+          identifier\tA
+          identifier\tB
       scoped_expr
         expr_and
-          C
+          identifier\tC
           scoped_expr
             expr_xor
-              A
-              B
+              identifier\tA
+              identifier\tB
 """
         self.assertEqual(parser.tree.pretty(), expected_tree)
 
@@ -76,41 +76,41 @@ class DVRTLTestParser(unittest.TestCase):
         parser: Parser = parse("tests/dv/assert.dv", isfilename=True)
         expected_tree: str = """start
   reg
-    A
+    identifier\tA
     zero
     expr_xor
-      C
+      identifier\tC
       scoped_expr
         expr_xor
-          a
-          b
+          identifier\ta
+          identifier\tb
   reg
-    Ap
+    identifier\tAp
     zero
-    A
+    identifier\tA
   reg
-    B
+    identifier\tB
     one
-    B
+    identifier\tB
   reg
-    C
+    identifier\tC
     zero
     expr_or
       scoped_expr
         expr_and
-          A
-          B
+          identifier\tA
+          identifier\tB
       scoped_expr
         expr_and
-          C
+          identifier\tC
           scoped_expr
             expr_xor
-              A
-              B
+              identifier\tA
+              identifier\tB
   stmt_assert
     arith_xor
-      A
-      Ap
+      identifier\tA
+      identifier\tAp
 """
         self.assertEqual(parser.tree.pretty(), expected_tree)
 
@@ -121,132 +121,132 @@ class DVRTLTestParser(unittest.TestCase):
         parser: Parser = parse("tests/dv/mod.dv", isfilename=True)
         expected_tree: str = """start
   bind
-    sum
+    identifier\tsum
     module
       list_of_variables
-        a_in
-        b_in
-        c_in
+        identifier\ta_in
+        identifier\tb_in
+        identifier\tc_in
       body
         bind
-          axb
+          identifier\taxb
           expr_xor
-            a_in
-            b_in
+            identifier\ta_in
+            identifier\tb_in
         out
           expr_xor
-            c_in
-            axb
+            identifier\tc_in
+            identifier\taxb
   bind
-    carry
+    identifier\tcarry
     module
       list_of_variables
-        a_in
-        b_in
-        c_in
+        identifier\ta_in
+        identifier\tb_in
+        identifier\tc_in
       body
         bind
-          axb_
+          identifier\taxb_
           expr_xor
-            a_in
-            b_in
+            identifier\ta_in
+            identifier\tb_in
         bind
-          anb
+          identifier\tanb
           expr_and
-            a_in
-            b_in
+            identifier\ta_in
+            identifier\tb_in
         out
           expr_or
-            anb
+            identifier\tanb
             scoped_expr
               expr_and
-                c_in
-                axb_
+                identifier\tc_in
+                identifier\taxb_
   bind
-    add2_0
+    identifier\tadd2_0
     module
       list_of_variables
-        a1
-        a0
-        b1
-        b0
+        identifier\ta1
+        identifier\ta0
+        identifier\tb1
+        identifier\tb0
       out
         call
-          sum
+          identifier\tsum
           list_of_expr
-            a0
-            b0
+            identifier\ta0
+            identifier\tb0
             zero
   bind
-    add2_1
+    identifier\tadd2_1
     module
       list_of_variables
-        a1
-        a0
-        b1
-        b0
+        identifier\ta1
+        identifier\ta0
+        identifier\tb1
+        identifier\tb0
       body
         bind
-          c_0
+          identifier\tc_0
           call
-            carry
+            identifier\tcarry
             list_of_expr
-              a0
-              b0
+              identifier\ta0
+              identifier\tb0
               zero
         out
           call
-            sum
+            identifier\tsum
             list_of_expr
-              a1
-              b1
-              c_0
+              identifier\ta1
+              identifier\tb1
+              identifier\tc_0
   bind
-    carry2
+    identifier\tcarry2
     module
       list_of_variables
-        a1
-        a0
-        b1
-        b0
+        identifier\ta1
+        identifier\ta0
+        identifier\tb1
+        identifier\tb0
       body
         bind
-          carry0
+          identifier\tcarry0
           call
-            carry
+            identifier\tcarry
             list_of_expr
-              a0
-              b0
+              identifier\ta0
+              identifier\tb0
               zero
         out
           call
-            carry
+            identifier\tcarry
             list_of_expr
-              a1
-              b1
-              carry0
+              identifier\ta1
+              identifier\tb1
+              identifier\tcarry0
   bind
-    bit0
+    identifier\tbit0
     call
-      add2_0
+      identifier\tadd2_0
       list_of_expr
         zero
         one
         zero
         one
   bind
-    bit1
+    identifier\tbit1
     call
-      add2_1
+      identifier\tadd2_1
       list_of_expr
         zero
         one
         zero
         one
   bind
-    overflow
+    identifier\toverflow
     call
-      carry2
+      identifier\tcarry2
       list_of_expr
         zero
         one
@@ -257,15 +257,15 @@ class DVRTLTestParser(unittest.TestCase):
       arith_and
         scoped_arith
           eq
-            bit0
+            identifier\tbit0
             zero
         scoped_arith
           eq
-            bit1
+            identifier\tbit1
             one
       scoped_arith
         eq
-          overflow
+          identifier\toverflow
           zero
 """
         self.assertEqual(parser.tree.pretty(), expected_tree)
@@ -277,181 +277,178 @@ class DVRTLTestParser(unittest.TestCase):
         parser: Parser = parse("tests/dv/untyped.dv", isfilename=True)
         expected_tree: str = """start
   bind
-    sum
+    identifier	sum
     module
       list_of_variables
-        a_in
-        b_in
-        c_in
+        identifier	a_in
+        identifier	b_in
+        identifier	c_in
       contract
         one
         eq
-          res
+          identifier	res
           scoped_arith
             add
               add
-                a_in
-                b_in
-              c_in
+                identifier	a_in
+                identifier	b_in
+              identifier	c_in
       body
         bind
-          axb
+          identifier	axb
           expr_xor
-            a_in
-            b_in
+            identifier	a_in
+            identifier	b_in
         out
           expr_xor
-            c_in
-            axb
+            identifier	c_in
+            identifier	axb
   bind
-    carry
+    identifier	carry
     module
       list_of_variables
-        a_in
-        b_in
-        c_in
+        identifier	a_in
+        identifier	b_in
+        identifier	c_in
       body
         bind
-          axb_
+          identifier	axb_
           expr_xor
-            a_in
-            b_in
+            identifier	a_in
+            identifier	b_in
         bind
-          anb
+          identifier	anb
           expr_and
-            a_in
-            b_in
+            identifier	a_in
+            identifier	b_in
         out
           expr_or
-            anb
+            identifier	anb
             scoped_expr
               expr_and
-                c_in
-                axb_
-  stmt_seq
-    stmt_seq
-      stmt_seq
-        bind
-          add2_0
-          module
-            list_of_variables
-              a1
-              a0
-              b1
-              b0
-            contract
-              one
-              eq
-                res
-                scoped_arith
-                  add
-                    a0
-                    b0
-            out
-              call
-                sum
-                list_of_expr
-                  a0
-                  b0
-                  zero
-        bind
-          add2_1
-          module
-            list_of_variables
-              a1
-              a0
-              b1
-              b0
-            contract
-              one
-              eq
-                res
-                scoped_arith
-                  add
-                    scoped_arith
-                      arith_and
-                        a0
-                        b0
-                    scoped_arith
-                      add
-                        a1
-                        b1
-            body
-              bind
-                c_0
-                call
-                  carry
-                  list_of_expr
-                    a0
-                    b0
-                    zero
-              out
-                call
-                  sum
-                  list_of_expr
-                    a1
-                    b1
-                    c_0
-      bind
-        carry2
-        module
-          list_of_variables
-            a1
-            a0
-            b1
-            b0
-          contract
-            one
-            eq
-              res
+                identifier	c_in
+                identifier	axb_
+  bind
+    identifier	add2_0
+    module
+      list_of_variables
+        identifier	a1
+        identifier	a0
+        identifier	b1
+        identifier	b0
+      contract
+        one
+        eq
+          identifier	res
+          scoped_arith
+            add
+              identifier	a0
+              identifier	b0
+      out
+        call
+          identifier	sum
+          list_of_expr
+            identifier	a0
+            identifier	b0
+            zero
+  bind
+    identifier	add2_1
+    module
+      list_of_variables
+        identifier	a1
+        identifier	a0
+        identifier	b1
+        identifier	b0
+      contract
+        one
+        eq
+          identifier	res
+          scoped_arith
+            add
+              scoped_arith
+                arith_and
+                  identifier	a0
+                  identifier	b0
               scoped_arith
                 add
-                  scoped_arith
-                    arith_and
-                      a0
-                      b0
-                  scoped_arith
-                    arith_and
-                      a1
-                      b1
-          body
-            bind
-              carry0
-              call
-                carry
-                list_of_expr
-                  a0
-                  b0
-                  zero
-            out
-              call
-                carry
-                list_of_expr
-                  a1
-                  b1
-                  carry0
-    bind
-      bit0
-      call
-        add2_0
-        list_of_expr
-          zero
-          one
-          zero
-          one
+                  identifier	a1
+                  identifier	b1
+      body
+        bind
+          identifier	c_0
+          call
+            identifier	carry
+            list_of_expr
+              identifier	a0
+              identifier	b0
+              zero
+        out
+          call
+            identifier	sum
+            list_of_expr
+              identifier	a1
+              identifier	b1
+              identifier	c_0
   bind
-    bit1
+    identifier	carry2
+    module
+      list_of_variables
+        identifier	a1
+        identifier	a0
+        identifier	b1
+        identifier	b0
+      contract
+        one
+        eq
+          identifier	res
+          scoped_arith
+            add
+              scoped_arith
+                arith_and
+                  identifier	a0
+                  identifier	b0
+              scoped_arith
+                arith_and
+                  identifier	a1
+                  identifier	b1
+      body
+        bind
+          identifier	carry0
+          call
+            identifier	carry
+            list_of_expr
+              identifier	a0
+              identifier	b0
+              zero
+        out
+          call
+            identifier	carry
+            list_of_expr
+              identifier	a1
+              identifier	b1
+              identifier	carry0
+  bind
+    identifier	bit0
     call
-      add2_1
+      identifier	add2_0
       list_of_expr
         zero
         one
         zero
         one
   bind
-    overflow
+    identifier	bit1
     call
-      carry2
+      identifier	add2_1
+      list_of_expr
+        zero
+        one
+        zero
+        one
+  bind
+    identifier	overflow
+    call
+      identifier	carry2
       list_of_expr
         zero
         one
@@ -462,15 +459,15 @@ class DVRTLTestParser(unittest.TestCase):
       arith_and
         scoped_arith
           eq
-            bit0
+            identifier	bit0
             zero
         scoped_arith
           eq
-            bit1
+            identifier	bit1
             one
       scoped_arith
         eq
-          overflow
+          identifier	overflow
           zero
 """
         self.assertEqual(parser.tree.pretty(), expected_tree)
@@ -481,7 +478,7 @@ class DVRTLTestParser(unittest.TestCase):
     def test_ast_mini(self):
       parser: Parser = parse("tests/dv/mini.dv", isfilename=True)
       
-      print(parser.ast)
+      print(parser.ast.toString())
       expected_ast = parser.ast
 
       self.assertEqual(parser.ast, expected_ast)

--- a/tests/test.py
+++ b/tests/test.py
@@ -277,178 +277,178 @@ class DVRTLTestParser(unittest.TestCase):
         parser: Parser = parse("tests/dv/untyped.dv", isfilename=True)
         expected_tree: str = """start
   bind
-    identifier	sum
+    identifier\tsum
     module
       list_of_variables
-        identifier	a_in
-        identifier	b_in
-        identifier	c_in
+        identifier\ta_in
+        identifier\tb_in
+        identifier\tc_in
       contract
         one
         eq
-          identifier	res
+          identifier\tres
           scoped_arith
             add
               add
-                identifier	a_in
-                identifier	b_in
-              identifier	c_in
+                identifier\ta_in
+                identifier\tb_in
+              identifier\tc_in
       body
         bind
-          identifier	axb
+          identifier\taxb
           expr_xor
-            identifier	a_in
-            identifier	b_in
+            identifier\ta_in
+            identifier\tb_in
         out
           expr_xor
-            identifier	c_in
-            identifier	axb
+            identifier\tc_in
+            identifier\taxb
   bind
-    identifier	carry
+    identifier\tcarry
     module
       list_of_variables
-        identifier	a_in
-        identifier	b_in
-        identifier	c_in
+        identifier\ta_in
+        identifier\tb_in
+        identifier\tc_in
       body
         bind
-          identifier	axb_
+          identifier\taxb_
           expr_xor
-            identifier	a_in
-            identifier	b_in
+            identifier\ta_in
+            identifier\tb_in
         bind
-          identifier	anb
+          identifier\tanb
           expr_and
-            identifier	a_in
-            identifier	b_in
+            identifier\ta_in
+            identifier\tb_in
         out
           expr_or
-            identifier	anb
+            identifier\tanb
             scoped_expr
               expr_and
-                identifier	c_in
-                identifier	axb_
+                identifier\tc_in
+                identifier\taxb_
   bind
-    identifier	add2_0
+    identifier\tadd2_0
     module
       list_of_variables
-        identifier	a1
-        identifier	a0
-        identifier	b1
-        identifier	b0
+        identifier\ta1
+        identifier\ta0
+        identifier\tb1
+        identifier\tb0
       contract
         one
         eq
-          identifier	res
+          identifier\tres
           scoped_arith
             add
-              identifier	a0
-              identifier	b0
+              identifier\ta0
+              identifier\tb0
       out
         call
-          identifier	sum
+          identifier\tsum
           list_of_expr
-            identifier	a0
-            identifier	b0
+            identifier\ta0
+            identifier\tb0
             zero
   bind
-    identifier	add2_1
+    identifier\tadd2_1
     module
       list_of_variables
-        identifier	a1
-        identifier	a0
-        identifier	b1
-        identifier	b0
+        identifier\ta1
+        identifier\ta0
+        identifier\tb1
+        identifier\tb0
       contract
         one
         eq
-          identifier	res
+          identifier\tres
           scoped_arith
             add
-              scoped_arith
-                arith_and
-                  identifier	a0
-                  identifier	b0
+              scoped_expr
+                expr_and
+                  identifier\ta0
+                  identifier\tb0
               scoped_arith
                 add
-                  identifier	a1
-                  identifier	b1
+                  identifier\ta1
+                  identifier\tb1
       body
         bind
-          identifier	c_0
+          identifier\tc_0
           call
-            identifier	carry
+            identifier\tcarry
             list_of_expr
-              identifier	a0
-              identifier	b0
+              identifier\ta0
+              identifier\tb0
               zero
         out
           call
-            identifier	sum
+            identifier\tsum
             list_of_expr
-              identifier	a1
-              identifier	b1
-              identifier	c_0
+              identifier\ta1
+              identifier\tb1
+              identifier\tc_0
   bind
-    identifier	carry2
+    identifier\tcarry2
     module
       list_of_variables
-        identifier	a1
-        identifier	a0
-        identifier	b1
-        identifier	b0
+        identifier\ta1
+        identifier\ta0
+        identifier\tb1
+        identifier\tb0
       contract
         one
         eq
-          identifier	res
+          identifier\tres
           scoped_arith
             add
-              scoped_arith
-                arith_and
-                  identifier	a0
-                  identifier	b0
-              scoped_arith
-                arith_and
-                  identifier	a1
-                  identifier	b1
+              scoped_expr
+                expr_and
+                  identifier\ta0
+                  identifier\tb0
+              scoped_expr
+                expr_and
+                  identifier\ta1
+                  identifier\tb1
       body
         bind
-          identifier	carry0
+          identifier\tcarry0
           call
-            identifier	carry
+            identifier\tcarry
             list_of_expr
-              identifier	a0
-              identifier	b0
+              identifier\ta0
+              identifier\tb0
               zero
         out
           call
-            identifier	carry
+            identifier\tcarry
             list_of_expr
-              identifier	a1
-              identifier	b1
-              identifier	carry0
+              identifier\ta1
+              identifier\tb1
+              identifier\tcarry0
   bind
-    identifier	bit0
+    identifier\tbit0
     call
-      identifier	add2_0
+      identifier\tadd2_0
       list_of_expr
         zero
         one
         zero
         one
   bind
-    identifier	bit1
+    identifier\tbit1
     call
-      identifier	add2_1
+      identifier\tadd2_1
       list_of_expr
         zero
         one
         zero
         one
   bind
-    identifier	overflow
+    identifier\toverflow
     call
-      identifier	carry2
+      identifier\tcarry2
       list_of_expr
         zero
         one
@@ -459,15 +459,15 @@ class DVRTLTestParser(unittest.TestCase):
       arith_and
         scoped_arith
           eq
-            identifier	bit0
+            identifier\tbit0
             zero
         scoped_arith
           eq
-            identifier	bit1
+            identifier\tbit1
             one
       scoped_arith
         eq
-          identifier	overflow
+          identifier\toverflow
           zero
 """
         self.assertEqual(parser.tree.pretty(), expected_tree)


### PR DESCRIPTION
I would like to support expressions of the sort:
```
A -> 0, (A and 1)
```
Without having to enforce a strict SSA-ification by the user
```
ano = A and 1
A -> 0, ano
```