### PR TITLE
[WIP] Bugfix for AST creation with modules and contracts

### DIFF
--- a/src/syntax.py
+++ b/src/syntax.py
@@ -508,7 +508,7 @@ class Contract(Node):
 
     @override
     def serialize(self) -> str:
-        return f"[{self.pre.serialize()}; {self.post.serialize()}]"
+        return f"[\n\t{self.pre.serialize()}\n\t{self.post.serialize()}\n]"
     
     @override
     def toString(self) -> str:
@@ -559,7 +559,7 @@ class Body(Node):
     @override
     def serialize(self) -> str:
         return reduce( \
-                lambda acc, stmt: acc + f"\t {stmt.serialize()}\n",\
+                lambda acc, stmt: acc + f"\t{stmt.serialize()}\n",\
                 self.stmts, "{\n" \
             ) + "}"
     
@@ -584,6 +584,19 @@ class Module(Stmt):
         self.args: list[In] = args
         self.contract: Optional[Contract] = contract
         self.body: Body = body 
+
+    @override
+    def serialize(self) -> str:
+        # Handle the case where either no arguments are given or empty arguments are given
+        args_s: str = "" if self.args is None else reduce( \
+            lambda acc, arg: acc + ", " + (arg.serialize() if arg is not None else ""), \
+            self.args, "" \
+        )
+        interface: str = f"{self.name} ({args_s}) "
+        contract: str = "" if self.contract is None else self.contract.serialize()
+        body: str = self.body.serialize()
+        
+        return f"{interface}{contract}{body}"
 
     @override
     def toString(self) -> str:

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -198,6 +198,7 @@ class DVRTLTransformer(Transformer):
             out_res = out
         return Body(l_s, out_res)
     
+    #TODO: FIX MODULE TRANSFORMER TO INCLUDE ARGUMENTS AND BODY CORRECTLY
     def module(self, c):
         (l_v, cntr, b) = (c[0:-2], c[-2], c[-1])
         cntr_res = None # avoid aliasing

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -117,7 +117,16 @@ class DVRTLTransformer(Transformer):
             s.expr for s in self.context \
             if s.name == name and isinstance(s.expr, Module) \
         ]
-        print(f"CONTEXT: {list(map(lambda sym: (sym.name, sym.expr.serialize()), self.context))}")
+
+        # Workaround for printing either typed objects because mypy is stupid
+        def sym_to_str(sym: Symbol) -> str:
+            if sym.expr is None:
+                return (sym.name, "")
+            return (sym.name, sym.expr.serialize())
+        
+        # debug print
+        print(f"CONTEXT: {list(map(sym_to_str, self.context))}")
+        
         assert len(mods) != 0, f"No module with name {name} was found!"
         return Inst(mods[0], l_e)
     

--- a/tests/dv/untyped.dv
+++ b/tests/dv/untyped.dv
@@ -1,7 +1,7 @@
 sum = mod (a_in, b_in, c_in) [
     req 1
     ens res eq (a_in + b_in + c_in)
-]{
+] {
     axb = a_in xor b_in
     out c_in xor axb
 }
@@ -19,14 +19,14 @@ add2_0 = mod (a1, a0, b1, b0) [
 add2_1 = mod (a1, a0, b1, b0) [
     req 1
     ens res eq ((a0 and b0) + (a1 + b1))
-]{
+] {
     c_0 = carry(a0, b0, 0)
     out sum(a1, b1, c_0)
 }
 carry2 = mod (a1, a0, b1, b0) [
     req 1
     ens res eq ((a0 and b0) + (a1 and b1))
-]{
+] {
     carry0 = carry(a0, b0, 0)
     out carry(a1, b1, carry0)
 }


### PR DESCRIPTION
The current implementation of the transformer does not correctly handle symbols of modules, making it crash on module instances.
